### PR TITLE
LPS-141393 Small fix in the API key field path

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageaudit/PageAudit.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageaudit/PageAudit.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>API_FIELD</td>
-	<td>//textarea[contains(@id, 'apiKey')]</td>
+	<td>//textarea[contains(@name, 'apiKey')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
JIRA Ticket:
LPS-141393

Motivation:
Wrong path was causing a lot of poshi failures. Fixed.