### PR TITLE
[TS] LPS-155811 Incorrect assets shown for collections when combined segments enabled and user belongs to segments without personalized variations

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -709,7 +709,7 @@ public class AssetListAssetEntryProviderImpl
 					segmentEntryIds, SegmentsEntryConstants.ID_DEFAULT));
 		}
 
-		return longStream.mapToObj(
+		long[] filteredAndSortedSegmentEntryIds = longStream.mapToObj(
 			segmentsEntryId ->
 				_assetListEntrySegmentsEntryRelLocalService.
 					fetchAssetListEntrySegmentsEntryRel(
@@ -723,6 +723,14 @@ public class AssetListAssetEntryProviderImpl
 		).mapToLong(
 			segmentsEntryId -> segmentsEntryId
 		).toArray();
+
+		if (filteredAndSortedSegmentEntryIds.length == 0) {
+			filteredAndSortedSegmentEntryIds = new long[] {
+				SegmentsEntryConstants.ID_DEFAULT
+			};
+		}
+
+		return filteredAndSortedSegmentEntryIds;
 	}
 
 	private List<AssetEntry> _getDynamicAssetEntries(


### PR DESCRIPTION
Hi @liferay-tango!

This is a solution to [LPS-155811](https://issues.liferay.com/browse/LPS-155811) as agreed in [PTR-3103](https://issues.liferay.com/browse/PTR-3103).

In `master` the only issue to fix is making sure that we return the array `[0]` when none of the segments the user belongs to have an associated personalized variation.

(For older versions it will be necessary to backport the filtering by `Objects::nonNull` to discard particular segments without personalized variations.)

As explained in the LPS-155811, this issue can only be tested (in `master`) for manual collections, because for dynamic collections it's masked by another problem. Nevertheless, the fix in this pr should work for both collection types.

Please let me know if you have any questions. 

Thanks!